### PR TITLE
Fix critical bugs: thread-safety, null-checks, and operator precedence

### DIFF
--- a/src/main/java/de/veroxar/forceItemBattle/commands/SkipCommand.java
+++ b/src/main/java/de/veroxar/forceItemBattle/commands/SkipCommand.java
@@ -22,7 +22,7 @@ public class SkipCommand implements CommandExecutor {
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, @NotNull String[] args) {
 
         if (sender instanceof Player player) {
-            if (args.length == 0 || args.length == 1 & args[0].equalsIgnoreCase(player.getName())) {
+            if (args.length == 0 || (args.length == 1 && args[0].equalsIgnoreCase(player.getName()))) {
                 if (logic.hasTask(player)) {
                     logic.skipTask(player);
                     player.sendMessage(Messages.PREFIX.append(Component.text("Your task has been skipped!").color(NamedTextColor.GRAY)));

--- a/src/main/java/de/veroxar/forceItemBattle/countdown/GameCountdown.java
+++ b/src/main/java/de/veroxar/forceItemBattle/countdown/GameCountdown.java
@@ -18,6 +18,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class GameCountdown {
 
     Data data = ForceItemBattle.getData();
@@ -27,19 +29,21 @@ public class GameCountdown {
     TeamInventoryManager inventoryManager = data.getTeamInventoryManager();
     TeamManager teamManager = data.getTeamManager();
 
-    private boolean running;
-    private boolean finished;
-    private int time;
-    private boolean started;
+    private volatile boolean running;
+    private volatile boolean finished;
+    private final AtomicInteger time;
+    private volatile boolean started;
 
     public GameCountdown() {
+        int initialTime;
         if (countdownConfig.toFileConfiguration().getInt(".countdown") != 0) {
-            this.time = countdownConfig.toFileConfiguration().getInt(".countdown");
+            initialTime = countdownConfig.toFileConfiguration().getInt(".countdown");
         } else if (instance.getConfig().getInt(".time") != 0) {
-            this.time = instance.getConfig().getInt(".time");
+            initialTime = instance.getConfig().getInt(".time");
         } else {
-            this.time = 10800;
+            initialTime = 10800;
         }
+        this.time = new AtomicInteger(initialTime);
         this.running = false;
         this.finished = false;
         this.started = false;
@@ -67,11 +71,11 @@ public class GameCountdown {
     }
 
     public int getTime() {
-        return time;
+        return time.get();
     }
 
     public void setTime(int time) {
-        this.time = time;
+        this.time.set(time);
     }
 
     public void setStarted(boolean started) {
@@ -170,7 +174,7 @@ public class GameCountdown {
                      onEnd();
                  }
 
-                setTime(getTime() - 1);
+                time.decrementAndGet();
             }
         }.runTaskTimer(instance, 20, 20);
     }

--- a/src/main/java/de/veroxar/forceItemBattle/events/GameListener.java
+++ b/src/main/java/de/veroxar/forceItemBattle/events/GameListener.java
@@ -59,7 +59,7 @@ public class GameListener implements Listener {
         if (event.getEntity() instanceof Player player) {
             if (teamInventoryManager.isTeamMode()) {
                 String teamName = teamManager.getTeamName(player);
-                if (event.getItem().getItemStack().getType().equals(taskManager.getTeamTask(teamName).getMaterial())) {
+                if (teamName != null && event.getItem().getItemStack().getType().equals(taskManager.getTeamTask(teamName).getMaterial())) {
                     logic.completedTeamTask(teamName, false);
                 }
                 return;
@@ -111,7 +111,7 @@ public class GameListener implements Listener {
                 }
                 if (teamInventoryManager.isTeamMode()) {
                     String teamName = teamManager.getTeamName(player);
-                    if (event.getCurrentItem().getType().equals(taskManager.getTeamTask(teamName).getMaterial())) {
+                    if (teamName != null && event.getCurrentItem().getType().equals(taskManager.getTeamTask(teamName).getMaterial())) {
                         logic.completedTeamTask(teamName, false);
                     }
                     return;
@@ -135,7 +135,7 @@ public class GameListener implements Listener {
         if (event.getWhoClicked() instanceof Player player) {
             if (teamInventoryManager.isTeamMode()) {
                 String teamName = teamManager.getTeamName(player);
-                if (event.getCursor()!= null)
+                if (teamName != null && event.getCursor()!= null)
                     if (event.getCursor().getType().equals(taskManager.getTeamTask(teamName).getMaterial())) {
                         logic.completedTeamTask(teamName, false);
                     }
@@ -157,10 +157,13 @@ public class GameListener implements Listener {
             return;
 
         if (teamInventoryManager.isTeamMode()) {
+            String teamName = teamManager.getTeamName(event.getPlayer());
+            if (teamName == null) return;
+
             if (data.getInstance().getServer().getWorlds().getFirst().getGameRuleValue(GameRule.KEEP_INVENTORY).equals(false)) {
                 logic.giveJokerToTeam(event.getPlayer());
             }
-            logic.showBlockAbovePlayer(event.getPlayer(), taskManager.getTeamTask(teamManager.getTeamName(event.getPlayer())).getMaterial());
+            logic.showBlockAbovePlayer(event.getPlayer(), taskManager.getTeamTask(teamName).getMaterial());
             return;
         }
         if (data.getInstance().getServer().getWorlds().getFirst().getGameRuleValue(GameRule.KEEP_INVENTORY).equals(false)) {
@@ -196,9 +199,10 @@ public class GameListener implements Listener {
                     int delay = 1;
                     Bukkit.getScheduler().runTaskLater(data.getInstance(), () -> logic.showBlockAbovePlayer(player, taskManager.getTask(player.getUniqueId()).getMaterial()), delay);
                 }
-                if (logic.hasTeamTask(teamManager.getTeamName(player))) {
+                String teamName = teamManager.getTeamName(player);
+                if (teamName != null && logic.hasTeamTask(teamName)) {
                     int delay = 1;
-                    Bukkit.getScheduler().runTaskLater(data.getInstance(), () -> logic.showBlockAbovePlayer(player, taskManager.getTeamTask(teamManager.getTeamName(player)).getMaterial()), delay);
+                    Bukkit.getScheduler().runTaskLater(data.getInstance(), () -> logic.showBlockAbovePlayer(player, taskManager.getTeamTask(teamName).getMaterial()), delay);
                 }
             }
         }
@@ -212,7 +216,8 @@ public class GameListener implements Listener {
                 if (logic.hasTask(player)) {
                     logic.removeBlockAbovePlayer(player);
                 }
-                if (logic.hasTeamTask(teamManager.getTeamName(player))) {
+                String teamName = teamManager.getTeamName(player);
+                if (teamName != null && logic.hasTeamTask(teamName)) {
                     logic.removeBlockAbovePlayer(player);
                 }
             }
@@ -275,15 +280,18 @@ public class GameListener implements Listener {
         if (teamInventoryManager.isTeamMode()) {
             Player player = event.getPlayer();
             if (teamManager.hasTeam(player)) {
+                String playerTeamName = teamManager.getTeamName(player);
+                if (playerTeamName == null) return;
+
                 String teamName = "null";
                 String playerName = player.getName();
-                switch (teamManager.getTeamName(player).toLowerCase()) {
+                switch (playerTeamName.toLowerCase()) {
                     case "blue" -> teamName = "§9Blue";
                     case "red" -> teamName = "§cRed";
                     case "yellow" -> teamName = "§eYellow";
                     case "green" -> teamName = "§aGreen";
                 }
-                switch (teamManager.getTeamName(player).toLowerCase()) {
+                switch (playerTeamName.toLowerCase()) {
                     case "blue" -> playerName = "§9" + playerName;
                     case "red" -> playerName = "§c" + playerName;
                     case "yellow" -> playerName = "§e" + playerName;


### PR DESCRIPTION
This commit addresses three critical bugs identified in code review:

1. Fix bitwise AND operator bug in SkipCommand (line 25)
   - Changed & to && to prevent ArrayIndexOutOfBoundsException
   - Added parentheses for better readability
   - Bug occurred when args.length != 1, causing premature evaluation

2. Add null-safety checks in GameListener
   - Added null-checks for getTeamName() calls (lines 62, 114, 138-139, 163, 199-201, 215-216, 280)
   - Prevents NullPointerException when player has no team
   - Cached teamName in variables to avoid redundant calls

3. Improve thread-safety in GameCountdown
   - Made running, finished, started fields volatile
   - Changed time from int to AtomicInteger
   - Used atomic decrementAndGet() instead of manual decrement
   - Prevents race conditions in concurrent access

All fixes are backward-compatible with no API changes.